### PR TITLE
Update ontology header

### DIFF
--- a/so-xp.obo
+++ b/so-xp.obo
@@ -16,7 +16,7 @@ synonymtypedef: ebi_variants "ensembl variant terms"
 synonymtypedef: RNAMOD "RNA modification" EXACT
 synonymtypedef: VAR "variant annotation term"
 default-namespace: sequence
-ontology: so-xp.obo
+ontology: so
 
 [Term]
 id: SO:0000000


### PR DESCRIPTION
This fixes an issue whereby http://purl.obolibrary.org/obo/so.owl resolves to an ontology with a different ontology IRI, which breaks many import chains.

Note longer term I recommend a more conventional release layout where the release file is called so.obo and so.owl, so-xp is a historic artefact

See also #303

cc @mcourtot