### PR TITLE
Annotate ontology roots with IAO_0000700

### DIFF
--- a/so-edit.obo
+++ b/so-edit.obo
@@ -19,6 +19,10 @@ synonymtypedef: RNAMOD "RNA modification" EXACT
 synonymtypedef: VAR "variant annotation term"
 default-namespace: sequence
 ontology: so
+property_value: IAO:0000700 SO_0000400
+property_value: IAO:0000700 SO_0001260
+property_value: IAO:0000700 SO_0000110
+property_value: IAO:0000700 SO_0001060
 
 [Term]
 id: SO:0000000

--- a/so-edit.obo
+++ b/so-edit.obo
@@ -19,10 +19,10 @@ synonymtypedef: RNAMOD "RNA modification" EXACT
 synonymtypedef: VAR "variant annotation term"
 default-namespace: sequence
 ontology: so
-property_value: IAO:0000700 SO_0000400
-property_value: IAO:0000700 SO_0001260
-property_value: IAO:0000700 SO_0000110
-property_value: IAO:0000700 SO_0001060
+property_value: IAO:0000700 SO:0000400
+property_value: IAO:0000700 SO:0001260
+property_value: IAO:0000700 SO:0000110
+property_value: IAO:0000700 SO:0001060
 
 [Term]
 id: SO:0000000


### PR DESCRIPTION
Related to https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2149

## What this Does

Applies the annotation property [has ontology root term (IAO:0000700)](http://purl.obolibrary.org/obo/IAO_0000700) four times as the ontology level to list the four root terms:

1. SO:0000400
2. SO:0001260
3. SO:0000110
4. SO:0001060

It's true that this is already logically the root element, but this makes it explicit. This isn't actually the case for all ontologies.

## Why this is helpful

- the Ontology Lookup Service uses this to help better display ontologies
- if any of the four terms mentioned above are ever aligned with an upper ontology like BFO, it still will be the thing shown on OLS as the "root"
- this will be generally useful for things like alignment with COB since it makes it easier to figure out where the work will be

cc @matentzn